### PR TITLE
Removed unwanted function parameter

### DIFF
--- a/_includes/twitter.php
+++ b/_includes/twitter.php
@@ -41,7 +41,7 @@
 	$twitter = new TwitterAPITimeline($settings);
 	
 	$json = $twitter->setGetfield($getfield)	// Note: Set the GET field BEFORE calling buildOauth()
-				  	->buildOauth($url, $requestMethod)
+				  	->buildOauth($url)
 				 	->performRequest();
 				 			
 	$twitter_data = json_decode($json, true);	// Create an array with the fetched JSON data


### PR DESCRIPTION
Its giving error for $requestMethod variable. I have checked public function buildOauth($url) in twitter-api-oauth.php file . there also only one parameter was mentioned.